### PR TITLE
Align screenshot button with header

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
         <!-- Neuer Container für den Screenshot-Button - mit hohem Z-Index, damit er immer im Vordergrund ist -->
         <div id="screenshotButtonContainer" class="absolute top-0 right-0 py-2 px-4 z-40 flex items-center justify-end">
-            <button id="screenshotButton" class="bg-gray-800 hover:bg-gray-900 text-white p-1.5 rounded-md shadow-md transition-colors duration-200 flex items-center justify-center">
+            <button id="screenshotButton" class="bg-gray-800 hover:bg-gray-900 text-white h-5 w-5 p-0 rounded-md shadow-md transition-colors duration-200 flex items-center justify-center">
                 <!-- Minimalistisches Kamera SVG Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-camera">
                     <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3Z"/>


### PR DESCRIPTION
## Summary
- adjust camera button height so it matches the `overtourissimus` heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886335ea6b08321b57aa6a18098eb26