### PR TITLE
Reduce camera icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         <div id="screenshotButtonContainer" class="absolute top-0 right-0 py-2 px-4 z-40 flex items-center justify-end">
             <button id="screenshotButton" class="bg-gray-800 hover:bg-gray-900 text-white h-5 w-5 p-0 rounded-md shadow-md transition-colors duration-200 flex items-center justify-center focus:outline-none">
                 <!-- Minimalistisches Kamera SVG Icon -->
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-camera">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-camera">
                     <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3Z"/>
                     <circle cx="12" cy="13" r="3"/>
                 </svg>


### PR DESCRIPTION
## Summary
- shrink the camera icon inside the screenshot button while keeping the button size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68863a85c0dc83219399eb60073748fc